### PR TITLE
Fix issue with not all connections being deleted when node deleted.

### DIFF
--- a/sample.cpp
+++ b/sample.cpp
@@ -178,8 +178,10 @@ void ShowDemoWindow(bool*)
             {
                 for (auto& connection : node->connections)
                 {
-                    ((MyNode*) connection.input_node)->DeleteConnection(connection);
-                    ((MyNode*) connection.output_node)->DeleteConnection(connection);
+                    if (connection.input_node != node)
+                        ((MyNode*) connection.input_node)->DeleteConnection(connection);
+                    if (connection.output_node != node)
+                        ((MyNode*) connection.output_node)->DeleteConnection(connection);
                 }
                 delete node;
                 it = nodes.erase(it);


### PR DESCRIPTION
First if statement fixes issue with not all connections to node being deleted when node is deleted.  Second if statement prevents redundant DeleteConnection() calls from occurring.
![0](https://user-images.githubusercontent.com/10877045/63209961-de636d80-c09c-11e9-91fb-bd257f01e7cc.png)
![1](https://user-images.githubusercontent.com/10877045/63209962-de636d80-c09c-11e9-8d4c-e1f81248afbc.png)
![2](https://user-images.githubusercontent.com/10877045/63209963-defc0400-c09c-11e9-880b-b7c32d924731.png)


