### PR TITLE
Correct connection deletion order for multiple in/out situations.

### DIFF
--- a/sample.cpp
+++ b/sample.cpp
@@ -178,8 +178,17 @@ void ShowDemoWindow(bool*)
             {
                 for (auto& connection : node->connections)
                 {
-                    ((MyNode*) connection.input_node)->DeleteConnection(connection);
-                    ((MyNode*) connection.output_node)->DeleteConnection(connection);
+                    // Deletion order is critical in case multiple connections to a node exist
+                    if (connection.output_node == node)
+                    {
+                        ((MyNode*) connection.input_node)->DeleteConnection(connection);
+                        ((MyNode*) connection.output_node)->DeleteConnection(connection);
+                    }
+                    else
+                    {
+                        ((MyNode*) connection.output_node)->DeleteConnection(connection);
+                        ((MyNode*) connection.input_node)->DeleteConnection(connection);
+                    }
                 }
                 delete node;
                 it = nodes.erase(it);


### PR DESCRIPTION
Connecting two nodes to a single input creates a problem when deleting the input node, leaving a dangling connection. This is a valid situation in our use-case:

<img width="437" alt="Screenshot 2019-10-09 at 14 55 53" src="https://user-images.githubusercontent.com/10883985/66483225-f35ceb80-eaa4-11e9-8cb1-148fef739c9f.png">
