### PR TITLE
A few minor improvements/fixes

### DIFF
--- a/ImNodes.cpp
+++ b/ImNodes.cpp
@@ -224,7 +224,7 @@ void BeginCanvas(CanvasState* canvas)
 
     if (!ImGui::IsMouseDown(0) && ImGui::IsWindowHovered())
     {
-        if (ImGui::IsMouseDragging(1))
+        if (ImGui::IsMouseDragging(2))
             canvas->offset += io.MouseDelta;
 
         if (io.KeyShift && !io.KeyCtrl)
@@ -236,8 +236,13 @@ void BeginCanvas(CanvasState* canvas)
         if (!io.KeyShift && io.KeyCtrl)
         {
             if (io.MouseWheel != 0)
+            {
+                ImVec2 mouseRel = ImVec2{ ImGui::GetMousePos().x - ImGui::GetWindowPos().x, ImGui::GetMousePos().y - ImGui::GetWindowPos().y };
+                float prevZoom = canvas->zoom;
                 canvas->zoom = ImClamp(canvas->zoom + io.MouseWheel * canvas->zoom / 16.f, 0.3f, 3.f);
-            canvas->offset += ImGui::GetMouseDragDelta();
+                float zoomFactor = (prevZoom - canvas->zoom) / prevZoom;
+                canvas->offset += (mouseRel - canvas->offset) * zoomFactor;
+            }
         }
     }
 
@@ -494,7 +499,7 @@ void EndNode()
         {
             // Upon node creation we would like it to be positioned at the center of mouse cursor. This can be done only
             // once widget dimensions are known at the end of rendering and thus on the next frame.
-            node_pos = ImGui::GetMousePos() - ImGui::GetCurrentWindow()->Pos - canvas->offset - (node_rect.GetSize() / 2);
+            node_pos = (ImGui::GetMousePos() - ImGui::GetCurrentWindow()->Pos) / canvas->zoom - canvas->offset - (node_rect.GetSize() / 2);
             impl->auto_position_node_id = nullptr;
         }
         break;

--- a/ImNodesEz.cpp
+++ b/ImNodesEz.cpp
@@ -90,6 +90,15 @@ bool Slot(const char* title, int kind)
         {
             // Align output slots to the right edge of the node.
             ImGuiID max_width_id = ImGui::GetID("output-max-title-width");
+
+			// Reset max width if zoom has changed
+            ImGuiID canvas_zoom = ImGui::GetID("canvas-zoom");
+            if (storage->GetFloat(canvas_zoom, gCanvas->zoom) != gCanvas->zoom)
+            {
+                storage->SetFloat(max_width_id, 0.0f);
+            }
+            storage->SetFloat(canvas_zoom, gCanvas->zoom);
+
             float output_max_title_width = ImMax(storage->GetFloat(max_width_id, title_size.x), title_size.x);
             storage->SetFloat(max_width_id, output_max_title_width);
             float offset = (output_max_title_width + style.ItemSpacing.x) - title_size.x;

--- a/ImNodesEz.cpp
+++ b/ImNodesEz.cpp
@@ -91,7 +91,7 @@ bool Slot(const char* title, int kind)
             // Align output slots to the right edge of the node.
             ImGuiID max_width_id = ImGui::GetID("output-max-title-width");
 
-			// Reset max width if zoom has changed
+            // Reset max width if zoom has changed
             ImGuiID canvas_zoom = ImGui::GetID("canvas-zoom");
             if (storage->GetFloat(canvas_zoom, gCanvas->zoom) != gCanvas->zoom)
             {


### PR DESCRIPTION
- Zoom towards mouse position rather than origin.
- Fix incorrect placement of new nodes when zoom != 1.
- Reset max title width of output slots if the zoom level has changed. Previously the max width would incorrectly stay high if you zoomed in then out again.
- Pan with middle mouse button rather than right mouse button since the right button is being used for context menu. Maybe the preferred fix would have been to not popup the context menu if panning had just completed.