### PR TITLE
Patch for imgui 1.85

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ cmake_minimum_required(VERSION 3.1)
 project(ImNodes)
 
 set(CMAKE_CXX_STANDARD 14)
-set(IMNODES_IMGUI_VERSION "v1.80" CACHE STRING "ImGui version to use for building sample,")
+set(IMNODES_IMGUI_VERSION "1.85" CACHE STRING "ImGui version to use for building sample,")
 
 if (NOT IMGUI_DIR)
     if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
@@ -35,7 +35,7 @@ if (NOT IMGUI_DIR)
         # independently. These are not necessary when user is consuming library in their
         # own project.
         if (NOT EXISTS "${IMGUI_DIR}.zip")
-            file(DOWNLOAD "https://github.com/ocornut/imgui/archive/${IMNODES_IMGUI_VERSION}.zip" ${IMGUI_DIR}.zip)
+            file(DOWNLOAD "https://github.com/ocornut/imgui/archive/v${IMNODES_IMGUI_VERSION}.zip" ${IMGUI_DIR}.zip)
         endif ()
         if (NOT EXISTS "${IMGUI_DIR}")
             execute_process(COMMAND ${CMAKE_COMMAND} -E tar xzf ${IMGUI_DIR}.zip)


### PR DESCRIPTION
Not sure if this is useful but it might help others?
 
When using imgui 1.85 the downloaded CMakeLists.txt ends up in the wrong dir. It's a matter of leaving out the 'v' in the version string.

However the downloaded CMakeLists.txt for Imgui needs patching:

```
115c115
<     ${IMGUI_ROOT_DIR}/imgui_draw.cpp ${IMGUI_ROOT_DIR}/imgui_widgets.cpp
---
>     ${IMGUI_ROOT_DIR}/imgui_draw.cpp ${IMGUI_ROOT_DIR}/imgui_widgets.cpp ${IMGUI_ROOT_DIR}/imgui_tables.cpp
151,161c151,161
< if (NOT CMAKE_SYSTEM_NAME STREQUAL Emscripten)
<     add_library(imgui-gl3w INTERFACE)
<     target_sources(imgui-gl3w INTERFACE ${IMGUI_EXAMPLES_DIR}/libs/gl3w/GL/gl3w.c)
<     target_compile_definitions(imgui-gl3w INTERFACE -DIMGUI_IMPL_OPENGL_LOADER_GL3W=1)
<     target_include_directories(imgui-gl3w INTERFACE ${IMGUI_EXAMPLES_DIR}/libs/gl3w)
<     if (APPLE)
<         target_link_libraries(imgui-gl3w INTERFACE "-framework CoreFoundation")
<     else ()
<         target_link_libraries(imgui-gl3w INTERFACE ${CMAKE_DL_LIBS})
<     endif ()
< endif ()
---
> #if (NOT CMAKE_SYSTEM_NAME STREQUAL Emscripten)
> #    add_library(imgui-gl3w INTERFACE)
> #    target_sources(imgui-gl3w INTERFACE ${IMGUI_EXAMPLES_DIR}/libs/gl3w/GL/gl3w.c)
> #    target_compile_definitions(imgui-gl3w INTERFACE -DIMGUI_IMPL_OPENGL_LOADER_GL3W=1)
> #    target_include_directories(imgui-gl3w INTERFACE ${IMGUI_EXAMPLES_DIR}/libs/gl3w)
> #    if (APPLE)
> #        target_link_libraries(imgui-gl3w INTERFACE "-framework CoreFoundation")
> #    else ()
> #        target_link_libraries(imgui-gl3w INTERFACE ${CMAKE_DL_LIBS})
> #    endif ()
> #endif ()
175c175
<         target_link_libraries(SDL2::SDL2 INTERFACE ${SDL2_LIBRARIES})
---
>         target_link_libraries(SDL2::SDL2 INTERFACE ${SDL2_LIBRARIES} ${CMAKE_DL_LIBS})
323c323
<         target_link_libraries (imgui-opengl3 INTERFACE imgui OpenGL::GL)
---
>         target_link_libraries (imgui-opengl3 INTERFACE imgui OpenGL::GL ${CMAKE_DL_LIBS})
```