### PR TITLE
Some fixes and improvements

### DIFF
--- a/ImNodes.cpp
+++ b/ImNodes.cpp
@@ -195,8 +195,8 @@ bool RenderConnection(const ImVec2& input_pos, const ImVec2& output_pos, float t
 
     thickness *= canvas->Zoom;
 
-    ImVec2 p2 = input_pos - ImVec2{100 * canvas->Zoom, 0};
-    ImVec2 p3 = output_pos + ImVec2{100 * canvas->Zoom, 0};
+    ImVec2 p2 = input_pos - ImVec2{canvas->Style.CurveStrength * canvas->Zoom, 0};
+    ImVec2 p3 = output_pos + ImVec2{canvas->Style.CurveStrength * canvas->Zoom, 0};
 #if IMGUI_VERSION_NUM < 18000
     ImVec2 closest_pt = ImBezierClosestPointCasteljau(input_pos, p2, p3, output_pos, ImGui::GetMousePos(), style.CurveTessellationTol);
 #else
@@ -251,7 +251,7 @@ void BeginCanvas(CanvasState* canvas)
         }
     }
 
-    const float grid = 64.0f * canvas->Zoom;
+    const float grid = canvas->Style.GridSpacing * canvas->Zoom;
 
     ImVec2 pos = ImGui::GetWindowPos();
     ImVec2 size = ImGui::GetWindowSize();
@@ -431,7 +431,6 @@ bool BeginNode(void* node_id, ImVec2* pos, bool* selected)
 void EndNode()
 {
     assert(gCanvas != nullptr);
-    const ImGuiStyle& style = ImGui::GetStyle();
     ImDrawList* draw_list = ImGui::GetWindowDrawList();
     auto* canvas = gCanvas;
     auto* impl = canvas->_Impl;
@@ -443,16 +442,16 @@ void EndNode()
     ImGui::EndGroup();    // Slots and content group
 
     ImRect node_rect{
-        ImGui::GetItemRectMin() - style.ItemInnerSpacing * canvas->Zoom,
-        ImGui::GetItemRectMax() + style.ItemInnerSpacing * canvas->Zoom
+        ImGui::GetItemRectMin() - canvas->Style.NodeSpacing * canvas->Zoom,
+        ImGui::GetItemRectMax() + canvas->Style.NodeSpacing * canvas->Zoom
     };
 
     // Render frame
     draw_list->ChannelsSetCurrent(0);
 
     ImColor node_color = canvas->Colors[node_selected ? ColNodeActiveBg : ColNodeBg];
-    draw_list->AddRectFilled(node_rect.Min, node_rect.Max, node_color, style.FrameRounding);
-    draw_list->AddRect(node_rect.Min, node_rect.Max, canvas->Colors[ColNodeBorder], style.FrameRounding);
+    draw_list->AddRectFilled(node_rect.Min, node_rect.Max, node_color, canvas->Style.NodeRounding * canvas->Zoom);
+    draw_list->AddRect(node_rect.Min, node_rect.Max, canvas->Colors[ColNodeBorder], canvas->Style.NodeRounding * canvas->Zoom);
 
     // Create node item
     ImGuiID node_item_id = ImGui::GetID(node_id);

--- a/ImNodes.h
+++ b/ImNodes.h
@@ -25,13 +25,6 @@
 
 #include <imgui.h>
 
-//
-// Appearance can be styled by altering ImGui style before calls to ImNodes::*,
-// Style:
-//  * FrameRounding - node border rounding.
-//  * ItemInnerSpacing - spacing between node borders and node content.
-//
-
 namespace ImNodes
 {
 
@@ -66,6 +59,11 @@ struct IMGUI_API CanvasState
         /// Indent connection into slot widget a little. Useful when slot content covers connection end with some kind
         /// of icon (like a circle) and then no seam between icon and connection end is visible.
         float ConnectionIndent = 1.0f;
+
+        float GridSpacing = 64.0f;
+        float CurveStrength = 100.0f;
+        float NodeRounding = 5.0f;
+        ImVec2 NodeSpacing{4.0f, 4.0f};
     } Style;
     /// Implementation detail.
     _CanvasStateImpl* _Impl = nullptr;

--- a/ImNodes.h
+++ b/ImNodes.h
@@ -80,6 +80,8 @@ IMGUI_API void EndCanvas();
 IMGUI_API bool BeginNode(void* node_id, ImVec2* pos, bool* selected);
 /// Terminates current node. Should be called regardless of BeginNode() returns value.
 IMGUI_API void EndNode();
+/// Returns `true` if the current node is hovered. Call between `BeginNode()` and `EndNode()`.
+IMGUI_API bool IsNodeHovered();
 /// Specified node will be positioned at the mouse cursor on next frame. Call when new node is created.
 IMGUI_API void AutoPositionNode(void* node_id);
 /// Returns `true` when new connection is made. Connection information is returned into `connection` parameter. Must be

--- a/ImNodesEz.cpp
+++ b/ImNodesEz.cpp
@@ -71,7 +71,7 @@ bool Slot(const char* title, int kind)
     const float CIRCLE_RADIUS = 5.f * gCanvas->Zoom;
     ImVec2 title_size = ImGui::CalcTextSize(title);
     // Pull entire slot a little bit out of the edge so that curves connect into int without visible seams
-    float item_offset_x = style.ItemSpacing.x * gCanvas->Zoom;
+    float item_offset_x = style.ItemInnerSpacing.x + CIRCLE_RADIUS;
     if (!ImNodes::IsOutputSlotKind(kind))
         item_offset_x = -item_offset_x;
     ImGui::SetCursorScreenPos(ImGui::GetCursorScreenPos() + ImVec2{item_offset_x, 0});
@@ -103,7 +103,7 @@ bool Slot(const char* title, int kind)
 
             float output_max_title_width = ImMax(storage->GetFloat(max_width_id, title_size.x), title_size.x);
             storage->SetFloat(max_width_id, output_max_title_width);
-            float offset = (output_max_title_width + style.ItemSpacing.x) - title_size.x;
+            float offset = (output_max_title_width + style.ItemInnerSpacing.x) - title_size.x;
             ImGui::SetCursorPosX(ImGui::GetCursorPosX() + offset);
 
             ImGui::TextUnformatted(title);
@@ -143,6 +143,9 @@ void InputSlots(const SlotInfo* slots, int snum)
 {
     const auto& style = ImGui::GetStyle();
 
+    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, style.ItemSpacing * gCanvas->Zoom);
+    ImGui::PushStyleVar(ImGuiStyleVar_ItemInnerSpacing, style.ItemInnerSpacing * gCanvas->Zoom);
+
     // Render input slots
     ImGui::BeginGroup();
     {
@@ -153,6 +156,8 @@ void InputSlots(const SlotInfo* slots, int snum)
 
     // Move cursor to the next column
     ImGui::SetCursorScreenPos({ImGui::GetItemRectMax().x + style.ItemSpacing.x, ImGui::GetItemRectMin().y});
+
+    ImGui::PopStyleVar(2);
 
     // Begin region for node content
     ImGui::BeginGroup();
@@ -165,6 +170,9 @@ void OutputSlots(const SlotInfo* slots, int snum)
     // End region of node content
     ImGui::EndGroup();
 
+    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, style.ItemSpacing * gCanvas->Zoom);
+    ImGui::PushStyleVar(ImGuiStyleVar_ItemInnerSpacing, style.ItemInnerSpacing * gCanvas->Zoom);
+
     // Render output slots in the next column
     ImGui::SetCursorScreenPos({ImGui::GetItemRectMax().x + style.ItemSpacing.x, ImGui::GetItemRectMin().y});
     ImGui::BeginGroup();
@@ -173,6 +181,8 @@ void OutputSlots(const SlotInfo* slots, int snum)
             ImNodes::Ez::Slot(slots[i].title, ImNodes::OutputSlotKind(slots[i].kind));
     }
     ImGui::EndGroup();
+
+    ImGui::PopStyleVar(2);
 }
 
 }

--- a/ImNodesEz.cpp
+++ b/ImNodesEz.cpp
@@ -119,6 +119,9 @@ bool Slot(const char* title, int kind, ImVec2 &pos)
 
         ImGui::PushStyleColor(ImGuiCol_Text, color.Value);
 
+        // Compensate for large slot circles.
+        ImGui::SetCursorPosY(ImGui::GetCursorPosY() + ImMax(CIRCLE_RADIUS - title_size.y*0.5f, 0.0f));
+
         if (ImNodes::IsOutputSlotKind(kind))
         {
             float *max_width_next = storage->GetFloatRef(ImGui::GetID("output-max-title-width-next"));

--- a/ImNodesEz.cpp
+++ b/ImNodesEz.cpp
@@ -34,6 +34,7 @@ extern CanvasState* gCanvas;
 namespace Ez
 {
 
+static ImVec4& GetStyleColorRef(ImNodesStyleCol idx);
 static ImU32 GetStyleColorU32(ImNodesStyleCol idx);
 
 struct StyleVarMod
@@ -149,17 +150,16 @@ void EndNode()
     GSplitter.SetCurrentChannel(draw_list, 0);
 
     // Render title bar background
-    // TODO: add configurable title color separate from body color.
-    ImColor node_color = canvas->Colors[*GNodeSelected ? ColNodeActiveBg : ColNodeBg];
+    ImU32 node_color = GetStyleColorU32(*GNodeSelected ? ImNodesStyleCol_NodeTitleBarActiveBg : ImNodesStyleCol_NodeTitleBarBg);
     draw_list->AddRectFilled(node_rect.Min, titlebar_end, node_color, canvas->Style.NodeRounding, ImDrawCornerFlags_Top);
 
     // Render body background
-    node_color = canvas->Colors[*GNodeSelected ? ColNodeActiveBg : ColNodeBg];
+    node_color = GetStyleColorU32(*GNodeSelected ? ImNodesStyleCol_NodeBodyActiveBg : ImNodesStyleCol_NodeBodyBg);
     draw_list->AddRectFilled(body_pos, node_rect.Max, node_color, canvas->Style.NodeRounding, ImDrawCornerFlags_Bot);
 
     // Render outlines
-    draw_list->AddRect(node_rect.Min, node_rect.Max, canvas->Colors[ColNodeBorder], canvas->Style.NodeRounding);
-    draw_list->AddLine(body_pos, titlebar_end, canvas->Colors[ColNodeBorder]);
+    draw_list->AddRect(node_rect.Min, node_rect.Max, GetStyleColorU32(ImNodesStyleCol_NodeBorder), canvas->Style.NodeRounding);
+    draw_list->AddLine(body_pos, titlebar_end, GetStyleColorU32(ImNodesStyleCol_NodeBorder));
 
     GSplitter.Merge(draw_list);
 }
@@ -185,7 +185,7 @@ bool Slot(const char* title, int kind, ImVec2 &pos)
         bool is_active = ImNodes::IsSlotCurveHovered() ||
                          (ImNodes::IsConnectingCompatibleSlot() /*&& !IsAlreadyConnectedWithPendingConnection(title, kind)*/);
 
-        ImColor color = gCanvas->Colors[is_active ? ImNodes::ColConnectionActive : ImNodes::ColConnection];
+        ImColor color = GetStyleColorRef(is_active ? ImNodesStyleCol_ConnectionActive : ImNodesStyleCol_Connection);
 
         ImGui::PushStyleColor(ImGuiCol_Text, color.Value);
 

--- a/ImNodesEz.cpp
+++ b/ImNodesEz.cpp
@@ -126,14 +126,17 @@ void EndNode()
     // Inhibit node rendering in ImNodes::EndNode() by setting colors with alpha as 0.
     ImColor activebg = gCanvas->Colors[ColNodeActiveBg];
     ImColor inactivebg = gCanvas->Colors[ColNodeBg];
+    ImColor border = gCanvas->Colors[ColNodeBorder];
     gCanvas->Colors[ColNodeActiveBg] = IM_COL32(0,0,0,0);
     gCanvas->Colors[ColNodeBg] = IM_COL32(0,0,0,0);
+    gCanvas->Colors[ColNodeBorder] = IM_COL32(0,0,0,0);
 
     ImNodes::EndNode();
 
     // Restore colors.
     gCanvas->Colors[ColNodeActiveBg] = activebg;
     gCanvas->Colors[ColNodeBg] = inactivebg;
+    gCanvas->Colors[ColNodeBorder] = border;
 
     ImRect node_rect{
         ImGui::GetItemRectMin(),

--- a/ImNodesEz.cpp
+++ b/ImNodesEz.cpp
@@ -169,6 +169,8 @@ void EndNode()
     Context &g = *GContext;
     ImDrawList* draw_list = ImGui::GetWindowDrawList();
 
+    bool hovered = IsNodeHovered();
+
     // Inhibit node rendering in ImNodes::EndNode() by setting colors with alpha as 0.
     ImColor activebg = g.State.Colors[ColNodeActiveBg];
     ImColor inactivebg = g.State.Colors[ColNodeBg];
@@ -195,11 +197,11 @@ void EndNode()
     g.Splitter.SetCurrentChannel(draw_list, 0);     // Background layer.
 
     // Render title bar background
-    ImU32 node_color = GetStyleColorU32(*g.NodeSelected ? ImNodesStyleCol_NodeTitleBarBgActive : ImNodesStyleCol_NodeTitleBarBg);
+    ImU32 node_color = GetStyleColorU32(*g.NodeSelected ? ImNodesStyleCol_NodeTitleBarBgActive : hovered ? ImNodesStyleCol_NodeTitleBarBgHovered : ImNodesStyleCol_NodeTitleBarBg);
     draw_list->AddRectFilled(node_rect.Min, titlebar_end, node_color, g.State.Style.NodeRounding, ImDrawCornerFlags_Top);
 
     // Render body background
-    node_color = GetStyleColorU32(*g.NodeSelected ? ImNodesStyleCol_NodeBodyBgActive : ImNodesStyleCol_NodeBodyBg);
+    node_color = GetStyleColorU32(*g.NodeSelected ? ImNodesStyleCol_NodeBodyBgActive : hovered ? ImNodesStyleCol_NodeBodyBgHovered : ImNodesStyleCol_NodeBodyBg);
     draw_list->AddRectFilled(body_pos, node_rect.Max, node_color, g.State.Style.NodeRounding, ImDrawCornerFlags_Bot);
 
     // Render outlines
@@ -410,6 +412,7 @@ static ImVec4& GetStyleColorRef(ImNodesStyleCol idx)
     {
     case ImNodesStyleCol_GridLines:             return g.State.Colors[ColCanvasLines].Value;
     case ImNodesStyleCol_NodeBodyBg:            return g.Style.Colors.NodeBodyBg;
+    case ImNodesStyleCol_NodeBodyBgHovered:     return g.Style.Colors.NodeBodyBgHovered;
     case ImNodesStyleCol_NodeBodyBgActive:      return g.Style.Colors.NodeBodyBgActive;
     case ImNodesStyleCol_NodeBorder:            return g.Style.Colors.NodeBorder;
     case ImNodesStyleCol_Connection:            return g.State.Colors[ColConnection].Value;
@@ -417,6 +420,7 @@ static ImVec4& GetStyleColorRef(ImNodesStyleCol idx)
     case ImNodesStyleCol_SelectBg:              return g.State.Colors[ColSelectBg].Value;
     case ImNodesStyleCol_SelectBorder:          return g.State.Colors[ColSelectBorder].Value;
     case ImNodesStyleCol_NodeTitleBarBg:        return g.Style.Colors.NodeTitleBarBg;
+    case ImNodesStyleCol_NodeTitleBarBgHovered: return g.Style.Colors.NodeTitleBarBgHovered;
     case ImNodesStyleCol_NodeTitleBarBgActive:  return g.Style.Colors.NodeTitleBarBgActive;
     default: IM_ASSERT(0);
     }

--- a/ImNodesEz.cpp
+++ b/ImNodesEz.cpp
@@ -195,11 +195,11 @@ void EndNode()
     g.Splitter.SetCurrentChannel(draw_list, 0);     // Background layer.
 
     // Render title bar background
-    ImU32 node_color = GetStyleColorU32(*g.NodeSelected ? ImNodesStyleCol_NodeTitleBarActiveBg : ImNodesStyleCol_NodeTitleBarBg);
+    ImU32 node_color = GetStyleColorU32(*g.NodeSelected ? ImNodesStyleCol_NodeTitleBarBgActive : ImNodesStyleCol_NodeTitleBarBg);
     draw_list->AddRectFilled(node_rect.Min, titlebar_end, node_color, g.State.Style.NodeRounding, ImDrawCornerFlags_Top);
 
     // Render body background
-    node_color = GetStyleColorU32(*g.NodeSelected ? ImNodesStyleCol_NodeBodyActiveBg : ImNodesStyleCol_NodeBodyBg);
+    node_color = GetStyleColorU32(*g.NodeSelected ? ImNodesStyleCol_NodeBodyBgActive : ImNodesStyleCol_NodeBodyBg);
     draw_list->AddRectFilled(body_pos, node_rect.Max, node_color, g.State.Style.NodeRounding, ImDrawCornerFlags_Bot);
 
     // Render outlines
@@ -410,14 +410,14 @@ static ImVec4& GetStyleColorRef(ImNodesStyleCol idx)
     {
     case ImNodesStyleCol_GridLines:             return g.State.Colors[ColCanvasLines].Value;
     case ImNodesStyleCol_NodeBodyBg:            return g.Style.Colors.NodeBodyBg;
-    case ImNodesStyleCol_NodeBodyActiveBg:      return g.Style.Colors.NodeBodyActiveBg;
+    case ImNodesStyleCol_NodeBodyBgActive:      return g.Style.Colors.NodeBodyBgActive;
     case ImNodesStyleCol_NodeBorder:            return g.Style.Colors.NodeBorder;
     case ImNodesStyleCol_Connection:            return g.State.Colors[ColConnection].Value;
     case ImNodesStyleCol_ConnectionActive:      return g.State.Colors[ColConnectionActive].Value;
     case ImNodesStyleCol_SelectBg:              return g.State.Colors[ColSelectBg].Value;
     case ImNodesStyleCol_SelectBorder:          return g.State.Colors[ColSelectBorder].Value;
     case ImNodesStyleCol_NodeTitleBarBg:        return g.Style.Colors.NodeTitleBarBg;
-    case ImNodesStyleCol_NodeTitleBarActiveBg:  return g.Style.Colors.NodeTitleBarActiveBg;
+    case ImNodesStyleCol_NodeTitleBarBgActive:  return g.Style.Colors.NodeTitleBarBgActive;
     default: IM_ASSERT(0);
     }
 }

--- a/ImNodesEz.h
+++ b/ImNodesEz.h
@@ -45,6 +45,7 @@ enum ImNodesStyleCol
 {
     ImNodesStyleCol_GridLines,
     ImNodesStyleCol_NodeBodyBg,
+    ImNodesStyleCol_NodeBodyBgHovered,
     ImNodesStyleCol_NodeBodyBgActive,
     ImNodesStyleCol_NodeBorder,
     ImNodesStyleCol_Connection,
@@ -52,6 +53,7 @@ enum ImNodesStyleCol
     ImNodesStyleCol_SelectBg,
     ImNodesStyleCol_SelectBorder,
     ImNodesStyleCol_NodeTitleBarBg,
+    ImNodesStyleCol_NodeTitleBarBgHovered,
     ImNodesStyleCol_NodeTitleBarBgActive,
     ImNodesStyleCol_COUNT,
 };
@@ -80,9 +82,11 @@ struct Style
     struct
     {
         ImVec4 NodeBodyBg{0.12f, 0.12f, 0.12f, 1.0f};
+        ImVec4 NodeBodyBgHovered{0.16f, 0.16f, 0.16f, 1.0f};
         ImVec4 NodeBodyBgActive{0.25f, 0.25f, 0.25f, 1.0f};
         ImVec4 NodeBorder{0.4f, 0.4f, 0.4f, 1.0f};
         ImVec4 NodeTitleBarBg{0.22f, 0.22f, 0.22f, 1.0f};
+        ImVec4 NodeTitleBarBgHovered{0.32f, 0.32f, 0.32f, 1.0f};
         ImVec4 NodeTitleBarBgActive{0.5f, 0.5f, 0.5f, 1.0f};
     } Colors;
 };

--- a/ImNodesEz.h
+++ b/ImNodesEz.h
@@ -45,14 +45,14 @@ enum ImNodesStyleCol
 {
     ImNodesStyleCol_GridLines,
     ImNodesStyleCol_NodeBodyBg,
-    ImNodesStyleCol_NodeBodyActiveBg,
+    ImNodesStyleCol_NodeBodyBgActive,
     ImNodesStyleCol_NodeBorder,
     ImNodesStyleCol_Connection,
     ImNodesStyleCol_ConnectionActive,
     ImNodesStyleCol_SelectBg,
     ImNodesStyleCol_SelectBorder,
     ImNodesStyleCol_NodeTitleBarBg,
-    ImNodesStyleCol_NodeTitleBarActiveBg,
+    ImNodesStyleCol_NodeTitleBarBgActive,
     ImNodesStyleCol_COUNT,
 };
 
@@ -80,10 +80,10 @@ struct Style
     struct
     {
         ImVec4 NodeBodyBg{0.12f, 0.12f, 0.12f, 1.0f};
-        ImVec4 NodeBodyActiveBg{0.25f, 0.25f, 0.25f, 1.0f};
+        ImVec4 NodeBodyBgActive{0.25f, 0.25f, 0.25f, 1.0f};
         ImVec4 NodeBorder{0.4f, 0.4f, 0.4f, 1.0f};
         ImVec4 NodeTitleBarBg{0.22f, 0.22f, 0.22f, 1.0f};
-        ImVec4 NodeTitleBarActiveBg{0.5f, 0.5f, 0.5f, 1.0f};
+        ImVec4 NodeTitleBarBgActive{0.5f, 0.5f, 0.5f, 1.0f};
     } Colors;
 };
 

--- a/ImNodesEz.h
+++ b/ImNodesEz.h
@@ -24,6 +24,23 @@
 
 #include "ImNodes.h"
 
+//
+// Appearance can be styled mid-frame by ImNodes::Ez::PushStyleVar()/ImNodes::Ez::PopStyleVar().
+//
+// Defined outside the ImNodes namespace similar to enums in ImGui.
+//
+enum ImNodesStyleVar
+{
+    ImNodesStyleVar_GridSpacing,        // float
+    ImNodesStyleVar_CurveThickness,     // float
+    ImNodesStyleVar_CurveStrength,      // float
+    ImNodesStyleVar_SlotRadius,         // float
+    ImNodesStyleVar_NodeRounding,       // float
+    ImNodesStyleVar_NodeSpacing,        // ImVec2
+    ImNodesStyleVar_ItemSpacing,        // ImVec2
+    ImNodesStyleVar_COUNT,
+};
+
 namespace ImNodes
 {
 
@@ -40,6 +57,12 @@ struct SlotInfo
     int kind;
 };
 
+struct Style
+{
+    float SlotRadius = 5.0f;
+    ImVec2 ItemSpacing{8.0f, 4.0f};
+};
+
 /// Begin rendering of node in a graph. Render node content when returns `true`.
 IMGUI_API bool BeginNode(void* node_id, const char* title, ImVec2* pos, bool* selected);
 /// Terminates current node. Should be called regardless of BeginNode() returns value.
@@ -52,6 +75,10 @@ IMGUI_API void InputSlots(const SlotInfo* slots, int snum);
 /// This function must always be called after InputSlots() and before EndNode().
 /// When no input slots are rendered call OutputSlots(nullptr, 0);
 IMGUI_API void OutputSlots(const SlotInfo* slots, int snum);
+
+IMGUI_API void PushStyleVar(ImNodesStyleVar idx, float val);
+IMGUI_API void PushStyleVar(ImNodesStyleVar idx, const ImVec2 &val);
+IMGUI_API void PopStyleVar(int count = 1);
 
 }
 

--- a/ImNodesEz.h
+++ b/ImNodesEz.h
@@ -115,6 +115,8 @@ IMGUI_API void InputSlots(const SlotInfo* slots, int snum);
 /// When no input slots are rendered call OutputSlots(nullptr, 0);
 IMGUI_API void OutputSlots(const SlotInfo* slots, int snum);
 
+bool Connection(void* input_node, const char* input_slot, void* output_node, const char* output_slot);
+
 IMGUI_API void PushStyleVar(ImNodesStyleVar idx, float val);
 IMGUI_API void PushStyleVar(ImNodesStyleVar idx, const ImVec2 &val);
 IMGUI_API void PopStyleVar(int count = 1);

--- a/ImNodesEz.h
+++ b/ImNodesEz.h
@@ -87,6 +87,17 @@ struct Style
     } Colors;
 };
 
+struct Context;
+
+IMGUI_API Context* CreateContext();
+IMGUI_API void FreeContext(Context *ctx);
+IMGUI_API void SetContext(Context *ctx);
+
+IMGUI_API ImNodes::CanvasState& GetState();
+
+IMGUI_API void BeginCanvas();
+IMGUI_API void EndCanvas();
+
 /// Begin rendering of node in a graph. Render node content when returns `true`.
 IMGUI_API bool BeginNode(void* node_id, const char* title, ImVec2* pos, bool* selected);
 /// Terminates current node. Should be called regardless of BeginNode() returns value.

--- a/ImNodesEz.h
+++ b/ImNodesEz.h
@@ -41,6 +41,21 @@ enum ImNodesStyleVar
     ImNodesStyleVar_COUNT,
 };
 
+enum ImNodesStyleCol
+{
+    ImNodesStyleCol_GridLines,
+    ImNodesStyleCol_NodeBodyBg,
+    ImNodesStyleCol_NodeBodyActiveBg,
+    ImNodesStyleCol_NodeBorder,
+    ImNodesStyleCol_Connection,
+    ImNodesStyleCol_ConnectionActive,
+    ImNodesStyleCol_SelectBg,
+    ImNodesStyleCol_SelectBorder,
+    ImNodesStyleCol_NodeTitleBarBg,
+    ImNodesStyleCol_NodeTitleBarActiveBg,
+    ImNodesStyleCol_COUNT,
+};
+
 namespace ImNodes
 {
 
@@ -57,10 +72,19 @@ struct SlotInfo
     int kind;
 };
 
+// Style which holds the extended variables and colors not already stored in ImNodes::CanvasState.
 struct Style
 {
     float SlotRadius = 5.0f;
     ImVec2 ItemSpacing{8.0f, 4.0f};
+    struct
+    {
+        ImVec4 NodeBodyBg;
+        ImVec4 NodeBodyActiveBg;
+        ImVec4 NodeBorder;
+        ImVec4 NodeTitleBarBg;
+        ImVec4 NodeTitleBarActiveBg;
+    } Colors;
 };
 
 /// Begin rendering of node in a graph. Render node content when returns `true`.
@@ -79,6 +103,10 @@ IMGUI_API void OutputSlots(const SlotInfo* slots, int snum);
 IMGUI_API void PushStyleVar(ImNodesStyleVar idx, float val);
 IMGUI_API void PushStyleVar(ImNodesStyleVar idx, const ImVec2 &val);
 IMGUI_API void PopStyleVar(int count = 1);
+
+IMGUI_API void PushStyleColor(ImNodesStyleCol idx, ImU32 col);
+IMGUI_API void PushStyleColor(ImNodesStyleCol idx, const ImVec4& col);
+IMGUI_API void PopStyleColor(int count);
 
 }
 

--- a/ImNodesEz.h
+++ b/ImNodesEz.h
@@ -79,11 +79,11 @@ struct Style
     ImVec2 ItemSpacing{8.0f, 4.0f};
     struct
     {
-        ImVec4 NodeBodyBg;
-        ImVec4 NodeBodyActiveBg;
-        ImVec4 NodeBorder;
-        ImVec4 NodeTitleBarBg;
-        ImVec4 NodeTitleBarActiveBg;
+        ImVec4 NodeBodyBg{0.12f, 0.12f, 0.12f, 1.0f};
+        ImVec4 NodeBodyActiveBg{0.25f, 0.25f, 0.25f, 1.0f};
+        ImVec4 NodeBorder{0.4f, 0.4f, 0.4f, 1.0f};
+        ImVec4 NodeTitleBarBg{0.22f, 0.22f, 0.22f, 1.0f};
+        ImVec4 NodeTitleBarActiveBg{0.5f, 0.5f, 0.5f, 1.0f};
     } Colors;
 };
 


### PR DESCRIPTION
Here are a couple of fixes and improvements I've made. Most of it is in ImNodes::Ez and I tried to keep the number of changes to the ImNodes namespace at a minimum. It's only improvements in ImNodes namespace the shouldn't affect any existing code that depends on it.

* Fixed smoother zooming
* Improved right alignment when title is wider than body
* Moving group of selected nodes does not change selection
* Clicking top-most node (as rendered) now selects it, not the bottom-most below it
* Added styling variables and colors (with stacks)
* Custom node rendering in ImNodes::Ez
* Added IsHovered() function to check if node is hovered
* Added support to handle multiple separate canvases by adding a Ez::Context
* Support to color hovered node differently from others
* Split rendering of nodes and connections into two layers
